### PR TITLE
Refactor header navigation for responsive layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { NavLink, Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import LessonsPage from './pages/LessonsPage';
@@ -19,43 +20,82 @@ const navItems = [
 
 const App = () => {
   const { app } = useAppData();
+  const getIsMobile = () => (typeof window !== 'undefined' ? window.innerWidth < 900 : false);
+  const [isMobile, setIsMobile] = useState(getIsMobile);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const evaluateViewport = () => {
+      const mobile = window.innerWidth < 900;
+      setIsMobile(mobile);
+      if (!mobile) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    evaluateViewport();
+    window.addEventListener('resize', evaluateViewport);
+
+    return () => {
+      window.removeEventListener('resize', evaluateViewport);
+    };
+  }, []);
+
   return (
-    <div>
-      <header style={{ 
-        background: 'linear-gradient(135deg, #f97316 0%, #ea580c 100%)', 
-        color: '#fff', 
-        padding: '16px 24px',
-        boxShadow: '0 4px 20px rgba(249, 115, 22, 0.3)'
-      }}>
-        <div className="container" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <div>
-            <div style={{ fontSize: '24px', fontWeight: 'bold', display: 'flex', alignItems: 'center', gap: '8px' }}>
-              ⌨️ TypingWizard
-            </div>
-            <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.9)', fontWeight: 500 }}>🎮 快乐打字 · 版本 {app.version}</div>
+    <div className="app-shell">
+      <header className={`app-header${isMenuOpen ? ' menu-open' : ''}`}>
+        <div className="app-header-inner">
+          <div className="app-logo" title={`TypingWizard · 版本 ${app.version}`}>
+            ⌨️ TypingWizard
           </div>
-          <nav style={{ display: 'flex', gap: 16 }}>
+          {isMobile ? (
+            <button
+              type="button"
+              className="app-menu-toggle"
+              aria-label="切换导航菜单"
+              aria-expanded={isMenuOpen}
+              aria-controls="app-nav-menu"
+              onClick={() => setIsMenuOpen((prev) => !prev)}
+            >
+              {isMenuOpen ? '✕' : '☰'}
+            </button>
+          ) : (
+            <nav className="app-nav app-nav-desktop">
+              {navItems.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) => `app-nav-link${isActive ? ' active' : ''}`}
+                >
+                  {item.label}
+                </NavLink>
+              ))}
+            </nav>
+          )}
+        </div>
+        {isMobile && (
+          <nav
+            id="app-nav-menu"
+            className={`app-nav app-nav-mobile${isMenuOpen ? ' open' : ''}`}
+          >
             {navItems.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}
-                style={({ isActive }) => ({
-                  color: '#fff',
-                  fontWeight: isActive ? 700 : 500,
-                  padding: '8px 16px',
-                  borderRadius: '999px',
-                  background: isActive ? 'rgba(255,255,255,0.2)' : 'transparent',
-                  transition: 'all 0.3s ease',
-                  fontSize: '16px'
-                })}
+                className={({ isActive }) => `app-nav-link${isActive ? ' active' : ''}`}
+                onClick={() => setIsMenuOpen(false)}
               >
                 {item.label}
               </NavLink>
             ))}
           </nav>
-        </div>
+        )}
       </header>
-      <main className="container" style={{ paddingBottom: 80 }}>
+      <main className="container app-main">
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/lessons" element={<LessonsPage />} />
@@ -67,7 +107,7 @@ const App = () => {
           <Route path="/about" element={<AboutPage />} />
         </Routes>
       </main>
-      <footer style={{ textAlign: 'center', padding: '24px', color: '#64748b', fontSize: 12 }}>
+      <footer className="app-footer">
         © {new Date().getFullYear()} TypingWizard · 所有数据仅存储在浏览器本地
       </footer>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -198,6 +198,139 @@ input[type='checkbox'] {
   align-items: center;
 }
 
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
+  color: #fff;
+  box-shadow: 0 4px 20px rgba(249, 115, 22, 0.3);
+  position: relative;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  min-height: 40px;
+}
+
+.app-header-inner {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.app-logo {
+  font-size: 18px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  letter-spacing: 0.3px;
+}
+
+.app-menu-toggle {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+}
+
+.app-menu-toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.app-nav {
+  display: flex;
+  gap: 12px;
+}
+
+.app-nav-link {
+  color: #fff;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  transition: all 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-nav-link:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.app-nav-link.active {
+  background: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 6px 16px rgba(255, 255, 255, 0.2);
+}
+
+.app-nav-mobile {
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 24px 20px;
+  background: rgba(17, 24, 39, 0.85);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.app-nav-mobile.open {
+  display: flex;
+}
+
+.app-nav-mobile .app-nav-link {
+  width: 100%;
+}
+
+.app-nav-desktop {
+  align-items: center;
+}
+
+.app-main {
+  padding-bottom: 80px;
+  flex: 1 0 auto;
+  width: 100%;
+}
+
+.app-footer {
+  text-align: center;
+  padding: 24px;
+  color: #64748b;
+  font-size: 12px;
+}
+
+@media (min-width: 900px) {
+  .app-header {
+    flex-direction: row;
+    align-items: center;
+    min-height: 40px;
+  }
+
+  .app-nav-desktop {
+    display: flex;
+  }
+}
+
+@media (max-width: 899px) {
+  .app-header.menu-open {
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.4);
+  }
+}
+
 .flex.center {
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace the header structure with a slim 40px layout and responsive menu toggle
- add state-driven mobile navigation overlay with hamburger control below the 900px breakpoint
- consolidate header, navigation, and footer styling into shared CSS for consistent typography and spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39363036883339d0dd321ca7a53bd