### PR TITLE
Adjust TrainPage layout constraints and highlight animation

### DIFF
--- a/src/pages/TrainPage.tsx
+++ b/src/pages/TrainPage.tsx
@@ -354,7 +354,16 @@ const TrainPage = () => {
   const timeColor = remainingTime < 30 ? '#ef4444' : remainingTime < 60 ? '#f97316' : '#22c55e';
 
   return (
-    <div style={{ marginTop: 24, position: 'relative' }}>
+    <div style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 900,
+          margin: '24px auto 48px',
+          padding: '0 16px',
+          position: 'relative'
+        }}
+      >
       {/* 成就弹出 - 移到顶部不挡住输入区 */}
       {showAchievement && (
         <div className="achievement-popup" style={{
@@ -381,7 +390,7 @@ const TrainPage = () => {
         background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
         color: '#fff',
         padding: '20px',
-        marginBottom: '16px',
+        marginBottom: '12px',
         border: '3px solid #f97316',
         boxShadow: '0 8px 32px rgba(249, 115, 22, 0.3)'
       }}>
@@ -521,17 +530,17 @@ const TrainPage = () => {
         </div>
       </div>
 
-      <div className={`card ${playerDamaged ? 'player-damaged' : ''}`} style={{ 
-        marginTop: 24,
+      <div className={`card ${playerDamaged ? 'player-damaged' : ''}`} style={{
+        marginTop: 16,
         background: 'linear-gradient(135deg, #1e293b 0%, #0f172a 100%)',
         border: '3px solid #f97316',
         boxShadow: '0 8px 32px rgba(249, 115, 22, 0.3)'
       }}>
         <div className="typing-container" onClick={() => textareaRef.current?.focus()} style={{
           background: 'transparent',
-          fontSize: '28px',
-          lineHeight: '1.6',
-          padding: '32px'
+          fontSize: '22px',
+          lineHeight: '1.5',
+          padding: '20px'
         }}>
           <div className="typing-text">
             {targetText.split('').map((char, index) => {
@@ -566,7 +575,7 @@ const TrainPage = () => {
             readOnly
           />
         </div>
-        <div style={{ marginTop: 24, display: 'flex', gap: 12 }}>
+        <div style={{ marginTop: 20, display: 'flex', gap: 12 }}>
           <button
             className="primary"
             onClick={() => handleFinish()}
@@ -612,7 +621,7 @@ const TrainPage = () => {
             </>
           )}
         </div>
-        <div style={{ marginTop: 16, color: '#94a3b8', fontSize: 16, textAlign: 'center', fontWeight: 'bold' }}>
+        <div className="typing-hint">
           💡 直接在键盘上敲击即可 · 建议切换为英文输入法
         </div>
       </div>
@@ -681,6 +690,7 @@ const TrainPage = () => {
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -251,8 +251,19 @@ kbd {
 }
 
 .typing-char.current {
-  background: rgba(250, 204, 21, 0.3);
+  background: rgba(59, 130, 246, 0.25);
   color: #0f172a;
+  animation: typing-current-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes typing-current-pulse {
+  0%,
+  100% {
+    background: rgba(59, 130, 246, 0.15);
+  }
+  50% {
+    background: rgba(59, 130, 246, 0.35);
+  }
 }
 
 .hud {
@@ -264,6 +275,21 @@ kbd {
   padding: 16px;
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.04);
+}
+
+.typing-hint {
+  margin-top: 12px;
+  color: #94a3b8;
+  font-size: 12px;
+  text-align: center;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+@media (max-height: 768px) {
+  .typing-hint {
+    display: none;
+  }
 }
 
 .hud-item {


### PR DESCRIPTION
## Summary
- center the training interface within a 900px wrapper, trim excess spacing, and lower the typing font size for a more compact layout
- restyle the active character highlight with a soft blue pulse and convert the input hint into a responsive caption that hides on short viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3936a6d9883338b5238589a150b58